### PR TITLE
Add collectible integration for templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,3 +85,10 @@ The deployed contract addresses can be found in `outputs/contracts/deployedContr
 
 
 
+
+## Template Contracts
+
+Example industry templates are provided in the `templates/` directory. These
+contracts offer simple starting points for common verticals such as cafés, gyms
+and e-commerce sites. Merchants can use them as-is or extend them to fit their
+needs.

--- a/contracts/src/interfaces/IInfiniRewardsCertificate.cairo
+++ b/contracts/src/interfaces/IInfiniRewardsCertificate.cairo
@@ -1,0 +1,12 @@
+use starknet::{ContractAddress, Span, felt252};
+
+#[starknet::interface]
+pub trait IInfiniRewardsCertificate<TContractState> {
+    fn mint(
+        ref self: TContractState,
+        account: ContractAddress,
+        token_id: u256,
+        value: u256,
+        data: Span<felt252>,
+    ) -> bool;
+}

--- a/contracts/src/interfaces/IInfiniRewardsCollectible.cairo
+++ b/contracts/src/interfaces/IInfiniRewardsCollectible.cairo
@@ -1,0 +1,12 @@
+use starknet::{ContractAddress, Span, felt252};
+
+#[starknet::interface]
+pub trait IInfiniRewardsCollectible<TContractState> {
+    fn mint(
+        ref self: TContractState,
+        account: ContractAddress,
+        token_id: u256,
+        value: u256,
+        data: Span<felt252>,
+    );
+}

--- a/contracts/src/interfaces/IInfiniRewardsPoints.cairo
+++ b/contracts/src/interfaces/IInfiniRewardsPoints.cairo
@@ -3,4 +3,5 @@ use starknet::ContractAddress;
 #[starknet::interface]
 pub trait IInfiniRewardsPoints<TContractState> {
     fn burn(ref self: TContractState, account: ContractAddress, amount: u256) -> bool;
+    fn mint(ref self: TContractState, account: ContractAddress, amount: u256) -> bool;
 }

--- a/templates/cafes/CafeRewardsContract.cairo
+++ b/templates/cafes/CafeRewardsContract.cairo
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: MIT
+
+#[starknet::contract]
+mod CafeRewardsContract {
+    use starknet::ContractAddress;
+    use starknet::storage::{StoragePointerReadAccess, StoragePointerWriteAccess, Map};
+    use contracts::interfaces::IInfiniRewardsPoints::IInfiniRewardsPointsDispatcher;
+    use contracts::interfaces::IInfiniRewardsPoints::IInfiniRewardsPointsDispatcherTrait;
+
+    #[storage]
+    struct Storage {
+        stamps_required: u8,
+        stamps: Map::<ContractAddress, u8>,
+        points_contract: ContractAddress,
+    }
+
+    #[event]
+    fn StampIssued(customer: ContractAddress, total: u8);
+
+    #[event]
+    fn FreeDrinkRedeemed(customer: ContractAddress);
+
+    #[constructor]
+    fn constructor(ref self: ContractState, stamps_required: u8, points_contract: ContractAddress) {
+        self.stamps_required.write(stamps_required);
+        self.points_contract.write(points_contract);
+    }
+
+    #[external]
+    fn issue_stamp(ref self: ContractState, customer: ContractAddress) {
+        let current = self.stamps.entry(customer).read();
+        let updated = current + 1_u8;
+        self.stamps.entry(customer).write(updated);
+        StampIssued(customer, updated);
+    }
+
+    #[external]
+    fn redeem_free_drink(ref self: ContractState, customer: ContractAddress) {
+        let count = self.stamps.entry(customer).read();
+        let required = self.stamps_required.read();
+        assert(count >= required, 'Not enough stamps');
+        self.stamps.entry(customer).write(0_u8);
+        let points_contract = self.points_contract.read();
+        let points_contract_dispatcher = IInfiniRewardsPointsDispatcher { contract_address: points_contract };
+        let _ = points_contract_dispatcher.mint(customer, required.into());
+        FreeDrinkRedeemed(customer);
+    }
+}

--- a/templates/cafes/README.md
+++ b/templates/cafes/README.md
@@ -1,0 +1,17 @@
+# Cafe Rewards Template
+
+This template provides a simple loyalty program for cafés using Cairo 2.0.
+Customers collect digital stamps and redeem a free drink once they reach the
+configured threshold. When a free drink is redeemed the customer also receives
+points via the `InfiniRewardsPoints` contract.
+
+## Key Features
+
+- Track stamps per customer address.
+- Configurable number of stamps required for a reward.
+- Basic functions to issue a stamp and redeem a free drink.
+- Demonstrates calling the shared `InfiniRewardsPoints` token contract to reward
+  customers.
+
+This contract is intended as a starting point and can be extended with
+additional logic or reward types.

--- a/templates/ecommerce/EcommerceRewardsContract.cairo
+++ b/templates/ecommerce/EcommerceRewardsContract.cairo
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: MIT
+
+#[starknet::contract]
+mod EcommerceRewardsContract {
+    use starknet::ContractAddress;
+    use starknet::storage::{StoragePointerReadAccess, StoragePointerWriteAccess, Map};
+    use contracts::interfaces::IInfiniRewardsPoints::IInfiniRewardsPointsDispatcher;
+    use contracts::interfaces::IInfiniRewardsPoints::IInfiniRewardsPointsDispatcherTrait;
+    use contracts::interfaces::IInfiniRewardsCollectible::IInfiniRewardsCollectibleDispatcher;
+    use contracts::interfaces::IInfiniRewardsCollectible::IInfiniRewardsCollectibleDispatcherTrait;
+    use core::integer::u256;
+    use array::ArrayTrait;
+
+    #[storage]
+    struct Storage {
+        cashback_rate: u8,
+        points_contract: ContractAddress,
+        voucher_collectible: ContractAddress,
+    }
+
+    #[constructor]
+    fn constructor(ref self: ContractState, cashback_rate: u8, points_contract: ContractAddress, voucher_collectible: ContractAddress) {
+        self.cashback_rate.write(cashback_rate);
+        self.points_contract.write(points_contract);
+        self.voucher_collectible.write(voucher_collectible);
+    }
+
+    #[external]
+    fn record_purchase(ref self: ContractState, buyer: ContractAddress, amount: u256) {
+        let points_contract = self.points_contract.read();
+        let dispatcher = IInfiniRewardsPointsDispatcher { contract_address: points_contract };
+        let _ = dispatcher.mint(buyer, amount);
+    }
+
+    #[external]
+    fn issue_voucher(ref self: ContractState, buyer: ContractAddress, token_id: u256) {
+        let coll = self.voucher_collectible.read();
+        let dispatcher = IInfiniRewardsCollectibleDispatcher { contract_address: coll };
+        let empty = ArrayTrait::new();
+        dispatcher.mint(buyer, token_id, 1_u256, empty.span());
+    }
+
+}

--- a/templates/ecommerce/README.md
+++ b/templates/ecommerce/README.md
@@ -1,0 +1,13 @@
+# E-commerce Rewards Template
+
+A minimal loyalty contract for online stores. It records purchases and directly
+mints points for the buyer via the shared `InfiniRewardsPoints` contract. It can
+also issue voucher collectibles through the `InfiniRewardsCollectible` contract.
+The template can be expanded to include cashback logic or deeper integration
+with the broader InfiniRewards ecosystem.
+
+## Key Features
+
+- Stores an optional cashback rate parameter.
+- Function to record a purchase and mint loyalty points for the buyer.
+- Ability to issue voucher collectibles to customers.

--- a/templates/gyms/GymMembershipContract.cairo
+++ b/templates/gyms/GymMembershipContract.cairo
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: MIT
+
+#[starknet::contract]
+mod GymMembershipContract {
+    use starknet::ContractAddress;
+    use starknet::storage::{StoragePointerReadAccess, StoragePointerWriteAccess, Map};
+    use starknet::syscalls::get_block_timestamp_syscall;
+    use array::ArrayTrait;
+    use contracts::interfaces::IInfiniRewardsCollectible::IInfiniRewardsCollectibleDispatcher;
+    use contracts::interfaces::IInfiniRewardsCollectible::IInfiniRewardsCollectibleDispatcherTrait;
+
+    #[storage]
+    struct Storage {
+        membership_duration: u64,
+        expiry: Map::<ContractAddress, u64>,
+        collectible_contract: ContractAddress,
+    }
+
+    #[constructor]
+    fn constructor(ref self: ContractState, membership_duration: u64, collectible_contract: ContractAddress) {
+        self.membership_duration.write(membership_duration);
+        self.collectible_contract.write(collectible_contract);
+    }
+
+    #[external]
+    fn register_member(ref self: ContractState, member: ContractAddress) {
+        let now = get_block_timestamp_syscall().timestamp;
+        let duration = self.membership_duration.read();
+        self.expiry.entry(member).write(now + duration);
+        let coll_contract = self.collectible_contract.read();
+        let coll_dispatcher = IInfiniRewardsCollectibleDispatcher { contract_address: coll_contract };
+        let empty = ArrayTrait::new();
+        coll_dispatcher.mint(member, 1_u256, 1_u256, empty.span());
+    }
+
+    #[view]
+    fn is_active(self: @ContractState, member: ContractAddress) -> bool {
+        let expires = self.expiry.entry(member).read();
+        let now = get_block_timestamp_syscall().timestamp;
+        return now < expires;
+    }
+}

--- a/templates/gyms/README.md
+++ b/templates/gyms/README.md
@@ -1,0 +1,16 @@
+# Gym Membership Template
+
+This template implements a basic membership system for gyms. Each member
+receives a membership with a fixed duration. When a member registers a
+collectible token is minted via the `InfiniRewardsCollectible` contract to
+represent the membership. The contract also stores the expiry timestamp and
+provides functions to register members and check their active status.
+
+## Key Features
+
+- Set a global membership duration on deployment.
+- Register members with an expiry date.
+- View method to verify if a membership is active.
+
+Extend this contract to add more advanced features such as session tracking or
+additional collectible types.


### PR DESCRIPTION
## Summary
- create `IInfiniRewardsCollectible` interface for minting collectible tokens
- use collectible contract for gym memberships
- allow e-commerce template to issue voucher collectibles
- document collectible usage in template READMEs

## Testing
- `npm run format:check`
- `npm test` *(fails: snforge not found)*
- `npm run compile`


------
https://chatgpt.com/codex/tasks/task_e_6843fb8c61648327ac27f01516867060